### PR TITLE
fix: Resolve topology bugs preventing labs from working

### DIFF
--- a/linux-plus/02-iptables-firewall-basics/topology.clab.yml
+++ b/linux-plus/02-iptables-firewall-basics/topology.clab.yml
@@ -29,10 +29,10 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils nginx
         - ip addr add 10.2.2.10/24 dev eth1
-        - ip route add default via 10.2.2.1
+        - ip route replace default via 10.2.2.1
         # Start nginx
-        - mkdir -p /run/nginx
-        - echo "<h1>Welcome to the webserver!</h1>" > /usr/share/nginx/html/index.html
+        - mkdir -p /run/nginx /var/www/html
+        - echo "<h1>Welcome to the webserver!</h1>" > /var/www/html/index.html
         - nginx
 
     # Client
@@ -42,7 +42,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils tcpdump curl nmap
         - ip addr add 10.1.1.10/24 dev eth1
-        - ip route add default via 10.1.1.1
+        - ip route replace default via 10.1.1.1
 
   links:
     - endpoints: ["firewall:eth1", "client:eth1"]

--- a/network-plus/01-static-routing-basics/topology.clab.yml
+++ b/network-plus/01-static-routing-basics/topology.clab.yml
@@ -45,7 +45,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils tcpdump
         - ip addr add 10.1.1.10/24 dev eth1
-        - ip route add default via 10.1.1.1
+        - ip route replace default via 10.1.1.1
 
     # PC2 - Right client
     pc2:
@@ -54,7 +54,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils tcpdump
         - ip addr add 10.3.3.10/24 dev eth1
-        - ip route add default via 10.3.3.3
+        - ip route replace default via 10.3.3.3
 
   links:
     - endpoints: ["r1:eth1", "pc1:eth1"]

--- a/network-plus/02-nat-pat-configuration/topology.clab.yml
+++ b/network-plus/02-nat-pat-configuration/topology.clab.yml
@@ -27,7 +27,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils tcpdump curl
         - ip addr add 10.1.1.10/24 dev eth1
-        - ip route add default via 10.1.1.1
+        - ip route replace default via 10.1.1.1
 
     # External server (simulates internet server)
     external-server:
@@ -36,7 +36,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils tcpdump python3
         - ip addr add 203.0.113.10/24 dev eth1
-        - ip route add default via 203.0.113.1
+        - ip route replace default via 203.0.113.1
         # Start simple HTTP server
         - nohup python3 -m http.server 80 > /dev/null 2>&1 &
 

--- a/network-plus/03-vlan-trunking/topology.clab.yml
+++ b/network-plus/03-vlan-trunking/topology.clab.yml
@@ -16,6 +16,7 @@ topology:
         - ip link set eth1 master br0
         - ip link set eth2 master br0
         - ip link set eth3 master br0
+        - ip link set eth4 master br0
         # Configure trunk port (eth1 to sw2) - allow VLANs 10, 20, 30
         - bridge vlan add vid 10 dev eth1
         - bridge vlan add vid 20 dev eth1
@@ -24,8 +25,10 @@ topology:
         # Configure access ports
         - bridge vlan add vid 10 dev eth2 pvid untagged
         - bridge vlan add vid 20 dev eth3 pvid untagged
+        - bridge vlan add vid 30 dev eth4 pvid untagged
         - bridge vlan del vid 1 dev eth2
         - bridge vlan del vid 1 dev eth3
+        - bridge vlan del vid 1 dev eth4
         # Add VLAN interfaces for inter-VLAN routing (Layer 3)
         - ip link add link br0 name br0.10 type vlan id 10
         - ip link add link br0 name br0.20 type vlan id 20
@@ -72,9 +75,9 @@ topology:
       kind: linux
       image: alpine:latest
       exec:
-        - ip addr add 10.10.10.10/24 dev eth1
-        - ip route add default via 10.10.10.1
         - apk add --no-cache iproute2 iputils bind-tools tcpdump
+        - ip addr add 10.10.10.10/24 dev eth1
+        - ip route replace default via 10.10.10.1
       binds:
         - configs/client1:/config:ro
 
@@ -83,9 +86,9 @@ topology:
       kind: linux
       image: alpine:latest
       exec:
-        - ip addr add 10.10.20.10/24 dev eth1
-        - ip route add default via 10.10.20.1
         - apk add --no-cache iproute2 iputils bind-tools tcpdump
+        - ip addr add 10.10.20.10/24 dev eth1
+        - ip route replace default via 10.10.20.1
       binds:
         - configs/client2:/config:ro
 
@@ -94,18 +97,27 @@ topology:
       kind: linux
       image: alpine:latest
       exec:
-        - ip addr add 10.10.10.11/24 dev eth1
-        - ip route add default via 10.10.10.1
         - apk add --no-cache iproute2 iputils bind-tools tcpdump
+        - ip addr add 10.10.10.11/24 dev eth1
+        - ip route replace default via 10.10.10.1
 
     # Client 4 - VLAN 20 (Sales)
     client4:
       kind: linux
       image: alpine:latest
       exec:
-        - ip addr add 10.10.20.11/24 dev eth1
-        - ip route add default via 10.10.20.1
         - apk add --no-cache iproute2 iputils bind-tools tcpdump
+        - ip addr add 10.10.20.11/24 dev eth1
+        - ip route replace default via 10.10.20.1
+
+    # Client 5 - VLAN 30 (Guest)
+    client5:
+      kind: linux
+      image: alpine:latest
+      exec:
+        - apk add --no-cache iproute2 iputils bind-tools tcpdump
+        - ip addr add 10.10.30.10/24 dev eth1
+        - ip route replace default via 10.10.30.1
 
   links:
     # Trunk link between sw1 and sw2
@@ -118,3 +130,4 @@ topology:
     # Access ports on sw1 (for inter-VLAN routing demo)
     - endpoints: ["sw1:eth2", "client3:eth1"]
     - endpoints: ["sw1:eth3", "client4:eth1"]
+    - endpoints: ["sw1:eth4", "client5:eth1"]

--- a/security-plus/01-dmz-network-design/topology.clab.yml
+++ b/security-plus/01-dmz-network-design/topology.clab.yml
@@ -2,18 +2,22 @@ name: dmz-network-design
 
 topology:
   nodes:
-    # Firewall (3 interfaces)
+    # Firewall (4 interfaces: external, DMZ, internal-client, internal-db)
     firewall:
       kind: linux
       image: alpine:latest
       exec:
-        - apk add --no-cache iproute2 iputils iptables tcpdump
+        - apk add --no-cache iproute2 iputils iptables tcpdump bridge-utils
         # External interface
         - ip addr add 203.0.113.1/24 dev eth1
         # DMZ interface
         - ip addr add 10.10.10.1/24 dev eth2
-        # Internal interface
-        - ip addr add 192.168.1.1/24 dev eth3
+        # Internal network - bridge eth3 and eth4 together
+        - ip link add name br-internal type bridge
+        - ip link set br-internal up
+        - ip link set eth3 master br-internal
+        - ip link set eth4 master br-internal
+        - ip addr add 192.168.1.1/24 dev br-internal
         # Enable forwarding
         - sysctl -w net.ipv4.ip_forward=1
         # Default DROP
@@ -23,11 +27,11 @@ topology:
         # External -> DMZ: Allow HTTP
         - iptables -A FORWARD -i eth1 -o eth2 -p tcp --dport 80 -j ACCEPT
         # DMZ -> Internal: Allow MySQL
-        - iptables -A FORWARD -i eth2 -o eth3 -p tcp --dport 3306 -j ACCEPT
+        - iptables -A FORWARD -i eth2 -o br-internal -p tcp --dport 3306 -j ACCEPT
         # Internal -> DMZ: Allow all
-        - iptables -A FORWARD -i eth3 -o eth2 -j ACCEPT
+        - iptables -A FORWARD -i br-internal -o eth2 -j ACCEPT
         # Internal -> External: Allow all
-        - iptables -A FORWARD -i eth3 -o eth1 -j ACCEPT
+        - iptables -A FORWARD -i br-internal -o eth1 -j ACCEPT
 
     # DMZ Webserver
     dmz-web:
@@ -36,9 +40,9 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils nginx mysql-client
         - ip addr add 10.10.10.10/24 dev eth1
-        - ip route add default via 10.10.10.1
-        - mkdir -p /run/nginx
-        - echo "<h1>DMZ Webserver</h1>" > /usr/share/nginx/html/index.html
+        - ip route replace default via 10.10.10.1
+        - mkdir -p /run/nginx /var/www/html
+        - echo "<h1>DMZ Webserver</h1>" > /var/www/html/index.html
         - nginx
 
     # Internal Database
@@ -48,7 +52,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils mariadb mariadb-client
         - ip addr add 192.168.1.10/24 dev eth1
-        - ip route add default via 192.168.1.1
+        - ip route replace default via 192.168.1.1
         # Initialize database
         - mkdir -p /run/mysqld /var/lib/mysql
         - chown -R mysql:mysql /run/mysqld /var/lib/mysql
@@ -62,7 +66,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils curl
         - ip addr add 192.168.1.20/24 dev eth1
-        - ip route add default via 192.168.1.1
+        - ip route replace default via 192.168.1.1
 
     # External Client
     external-client:
@@ -71,10 +75,10 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils curl
         - ip addr add 203.0.113.10/24 dev eth1
-        - ip route add default via 203.0.113.1
+        - ip route replace default via 203.0.113.1
 
   links:
     - endpoints: ["firewall:eth1", "external-client:eth1"]
     - endpoints: ["firewall:eth2", "dmz-web:eth1"]
     - endpoints: ["firewall:eth3", "internal-client:eth1"]
-    - endpoints: ["firewall:eth3", "internal-db:eth1"]
+    - endpoints: ["firewall:eth4", "internal-db:eth1"]

--- a/security-plus/03-network-segmentation-zones/topology.clab.yml
+++ b/security-plus/03-network-segmentation-zones/topology.clab.yml
@@ -41,7 +41,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils curl
         - ip addr add 10.10.0.10/24 dev eth1
-        - ip route add default via 10.10.0.1
+        - ip route replace default via 10.10.0.1
 
     # Engineering Client
     eng-client:
@@ -50,7 +50,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils curl
         - ip addr add 10.20.0.10/24 dev eth1
-        - ip route add default via 10.20.0.1
+        - ip route replace default via 10.20.0.1
 
     # Guest Client
     guest-client:
@@ -59,7 +59,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils curl
         - ip addr add 10.30.0.10/24 dev eth1
-        - ip route add default via 10.30.0.1
+        - ip route replace default via 10.30.0.1
 
     # Internet Server
     internet-server:
@@ -68,7 +68,7 @@ topology:
       exec:
         - apk add --no-cache iproute2 iputils python3
         - ip addr add 203.0.113.10/24 dev eth1
-        - ip route add default via 203.0.113.1
+        - ip route replace default via 203.0.113.1
         - nohup python3 -m http.server 80 > /dev/null 2>&1 &
 
   links:


### PR DESCRIPTION
## Summary

This PR fixes critical bugs that prevented labs from deploying correctly on containerlab.

### Bugs Fixed

1. **Default Route Conflict** (affects 6 labs)
   - Changed `ip route add default` to `ip route replace default`
   - Docker/containerlab adds its own default route, causing `ip route add` to fail with "File exists"

2. **DMZ Lab Dual-Link Bug** (security-plus/01-dmz-network-design)
   - Both `internal-client` and `internal-db` were connected to `firewall:eth3` 
   - This is an invalid topology - containerlab can't connect two nodes to the same endpoint
   - Fixed by creating a bridge interface on the firewall that connects eth3 and eth4

3. **Missing VLAN 30 Client** (network-plus/03-vlan-trunking)
   - sw1 configured VLAN 30 but no client existed to test it
   - Added `client5` on VLAN 30 (Guest) with eth4 port on sw1

4. **Nginx HTML Path**
   - Fixed nginx html path to `/var/www/html/` for Alpine compatibility

### Files Changed

| File | Changes |
|------|---------|
| network-plus/01-static-routing-basics/topology.clab.yml | Fix default routes |
| network-plus/02-nat-pat-configuration/topology.clab.yml | Fix default routes |
| network-plus/03-vlan-trunking/topology.clab.yml | Fix default routes, add client5 for VLAN 30 |
| security-plus/01-dmz-network-design/topology.clab.yml | Fix dual-link bug, fix default routes |
| security-plus/03-network-segmentation-zones/topology.clab.yml | Fix default routes |
| linux-plus/02-iptables-firewall-basics/topology.clab.yml | Fix default routes |

### Testing

Tested on ARM Mac (Apple Silicon) with OrbStack + containerlab v0.72.0:
- ✅ Topologies deploy without errors
- ✅ Routing works end-to-end
- ✅ NAT/iptables rules apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)