### PR TITLE
fix: Bash arithmetic exit code with set -e

### DIFF
--- a/linux-plus/01-network-interface-config/scripts/validate.sh
+++ b/linux-plus/01-network-interface-config/scripts/validate.sh
@@ -22,10 +22,10 @@ run_test() {
     echo -n "Testing: $test_name ... "
     if eval "$command" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/linux-plus/02-iptables-firewall-basics/scripts/validate.sh
+++ b/linux-plus/02-iptables-firewall-basics/scripts/validate.sh
@@ -18,10 +18,10 @@ run_test() {
     echo -n "Testing: $1 ... "
     if eval "$2" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/linux-plus/03-systemd-service-management/scripts/validate.sh
+++ b/linux-plus/03-systemd-service-management/scripts/validate.sh
@@ -13,10 +13,10 @@ run_test() {
     echo -n "Testing: $1 ... "
     if eval "$2" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/network-plus/01-static-routing-basics/scripts/validate.sh
+++ b/network-plus/01-static-routing-basics/scripts/validate.sh
@@ -25,10 +25,10 @@ run_test() {
 
     if eval "$command" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/network-plus/02-nat-pat-configuration/scripts/validate.sh
+++ b/network-plus/02-nat-pat-configuration/scripts/validate.sh
@@ -25,10 +25,10 @@ run_test() {
 
     if eval "$command" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/network-plus/03-vlan-trunking/scripts/validate.sh
+++ b/network-plus/03-vlan-trunking/scripts/validate.sh
@@ -29,10 +29,10 @@ run_test() {
 
     if eval "$command" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/security-plus/01-dmz-network-design/scripts/validate.sh
+++ b/security-plus/01-dmz-network-design/scripts/validate.sh
@@ -13,10 +13,10 @@ run_test() {
     echo -n "Testing: $1 ... "
     if eval "$2" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/security-plus/02-ssh-key-authentication/scripts/validate.sh
+++ b/security-plus/02-ssh-key-authentication/scripts/validate.sh
@@ -13,10 +13,10 @@ run_test() {
     echo -n "Testing: $1 ... "
     if eval "$2" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 

--- a/security-plus/03-network-segmentation-zones/scripts/validate.sh
+++ b/security-plus/03-network-segmentation-zones/scripts/validate.sh
@@ -13,10 +13,10 @@ run_test() {
     echo -n "Testing: $1 ... "
     if eval "$2" &> /dev/null; then
         echo -e "${GREEN}✅ PASS${NC}"
-        ((PASSED++))
+        ((PASSED++)) || true
     else
         echo -e "${RED}❌ FAIL${NC}"
-        ((FAILED++))
+        ((FAILED++)) || true
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixes the CI validation script failures caused by bash arithmetic exit codes.

### The Problem
When using `((PASSED++))` with `set -e` in bash, the script exits prematurely when `PASSED=0` because:
- `((0++))` evaluates to `0` (the original value before increment)
- In bash, an arithmetic expression that evaluates to `0` returns exit code `1`
- With `set -e`, any non-zero exit code causes the script to terminate

### The Fix
Added `|| true` after arithmetic increments to prevent false failures:
```bash
((PASSED++)) || true
((FAILED++)) || true
```

This is a common bash gotcha that was causing all 9 labs to fail in CI.

## Test plan

- [ ] CI workflow passes for all 9 labs
- [ ] Validation scripts correctly count pass/fail tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)