### PR TITLE
fix: NAT connection tracking test

### DIFF
--- a/network-plus/02-nat-pat-configuration/scripts/validate.sh
+++ b/network-plus/02-nat-pat-configuration/scripts/validate.sh
@@ -136,8 +136,9 @@ sleep 1
 run_test "NAT statistics show packet translations" \
     "docker exec clab-nat-pat-configuration-router iptables -t nat -L POSTROUTING -v -n | awk 'NR>2 {sum+=\$1} END {exit (sum>0)?0:1}'"
 
-run_test "Connection tracking file exists" \
-    "docker exec clab-nat-pat-configuration-router test -f /proc/net/nf_conntrack"
+# Note: /proc/net/nf_conntrack may not exist in containers without nf_conntrack module
+run_test "NAT masquerade is active" \
+    "docker exec clab-nat-pat-configuration-router iptables -t nat -L POSTROUTING -v -n | grep -i MASQUERADE"
 
 echo ""
 


### PR DESCRIPTION
The /proc/net/nf_conntrack file may not exist in containers. Changed to verify NAT masquerade is active instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)